### PR TITLE
Add compatibility for more single quotes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .venv/
+.vscode/
 config.ini
 *.Identifier
 .cache

--- a/mikey/DadCog.py
+++ b/mikey/DadCog.py
@@ -1,6 +1,10 @@
 from discord.ext import commands
 
 class Dad(commands.Cog):
+
+    # https://www.cl.cam.ac.uk/~mgk25/ucs/quotes.html
+    SINGLE_QUOTES = ["\u0027", "\u0060", "\u00B4", "\u2018", "\u2019"]
+
     def __init__(self, bot):
         self.bot = bot
 
@@ -27,7 +31,7 @@ def getNewName(search, msg):
     return msg[start:end]
         
 def dadJoke(message):
-    triggers = ["i'm ", "i am ", " im "]
+    triggers = [f"i{single_quote}m " for single_quote in Dad.SINGLE_QUOTES] + ["i am ", " im "]
     for word in triggers:
         if word in message.content.lower():
             name = getNewName(word, message.content)

--- a/mikey/DadCogSpec.py
+++ b/mikey/DadCogSpec.py
@@ -1,0 +1,35 @@
+import unittest
+import DadCog
+
+class MockMessage:
+
+    def __init__(self, author, content):
+        self.author = author
+        self.content = content
+
+class MockMessageAuthor:
+
+    def __init__(self, author):
+        self.id = author
+        self.bot = False
+
+class TestDadCogMethods(unittest.TestCase):
+
+    def test_single_quote(self):
+        test_user = "josh"
+
+        # https://www.cl.cam.ac.uk/~mgk25/ucs/quotes.html
+        single_quotes = ["\u0027", "\u0060", "\u00B4", "\u2018", "\u2019"]
+
+        test_strings = [f"I{single_quote}m a normal single quote" for single_quote in single_quotes]
+
+        expected_string = f"Hi a normal single quote, I thought you were <@{test_user}>."
+        
+        mock_messages = [MockMessage(MockMessageAuthor(test_user), test_string) for test_string in test_strings]
+
+        for mock_message in mock_messages:
+            with self.subTest(mock_message=mock_message.content):
+                self.assertEqual(DadCog.dadJoke(mock_message), expected_string)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
iOS doesn't use `'` as its single quote; it tends to use `‘` and `’`. This adds those characters as acceptable single quotes.

This PR also adds a test to ensure it works.